### PR TITLE
Can't read "botnick": no such variable

### DIFF
--- a/sitebot/plugins/DeluserBan.tcl
+++ b/sitebot/plugins/DeluserBan.tcl
@@ -103,7 +103,8 @@ namespace eval ::ngBot::plugin::DeluserBan {
         variable banUser
         variable message
         variable killUser
-        variable ${np}::botnick
+        #variable ${np}::botnick
+        global botnick
         if {![string equal "DELUSER" $event] && ![string equal "PURGED" $event]} {return 1}
 
         ## Log Data:


### PR DESCRIPTION
Fix: variable ${np}::botnick doesn't exist so use eggdrop's global variable botnick instead.