### PR TITLE
use abbreviated git commit hash as ng_version in case it's a git checkout

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -47,6 +47,7 @@ swho:
 
 libs:
 	@(printf "\n\033[1;37mCompiling the additional libraries\033[0m\n")
+	sh ./version.sh
 	cd lib/ ; $(MAKE) all
 
 utils:

--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,18 @@
+#/bin/sh
+# extract abbreviated hash from master
+if [ -f .git/refs/heads/master ]; then
+  GIT_HASH=$(cut -c"1-8" .git/refs/heads/master 2>&1 | tee)
+else GIT_HASH="svn-checkout"
+fi
+cat << EOF > zipscript/src/ng-version.c
+#include "ng-version.h"
+
+/*** 
+ * DO NOT CHANGE THIS FILE ON SVN PRIOR TO RELEASE!
+ * The bot (pzs-ng) takes care of this when you do something like:
+ *  <@psxc> pzs-ng: release 2291 stable v1.0.9
+ * So just leave this, so that you can identify a svn revision versus a normal release. :-)
+ ***/
+
+const char* ng_version = "${GIT_HASH}";
+EOF


### PR DESCRIPTION
adding a little shell script to change ng-version.c in case it's a git checkout.