### PR TITLE
psxc-imdb: added box office mojo support (screens/islimited) and fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,8 @@ PZS-NG CHANGELOG
 ----------------
 
 v1.2.0  --> 1.2.x :
+		- Fix psxc-imdb in many parts (thanks to silver)
+		- ^--- 2020 ---^
 		- Fix configure to detect glFTPd 2.10 and above
 		- Fix TVMaze to work with newer Tcl packages (thanks to teqnodude for reporting)
 		- Change hardcoded limit for justification in sitebot announces from 2 to 3 (thanks to h-0-s-h)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@ PZS-NG CHANGELOG
 ----------------
 
 v1.2.0  --> 1.2.x :
-		- Fix psxc-imdb in many parts (thanks to silver)
+		- Fix psxc-imdb in many parts (thanks to silv3rr)
 		- ^--- 2020 ---^
 		- Fix configure to detect glFTPd 2.10 and above
 		- Fix TVMaze to work with newer Tcl packages (thanks to teqnodude for reporting)

--- a/scripts/psxc-imdb/CHANGELOG
+++ b/scripts/psxc-imdb/CHANGELOG
@@ -7,6 +7,7 @@ PSXC-IMDB CHANGELOG:
                           - Added option to USECURL and FLAGS for both curl and wget
                           - Fixed Businessdata (opening earnings in BUSINESSSHORT)
                           - Fixed searching on iMDB.
+                          - Improve rescan
 - v2.9u - Dec  26th, 2017 - Fix main and find for new layout, no user reviews and screens anymore.
 - v2.9t - Feb  13th, 2017 - Removed trailing '|' for languages, comments, countries, certs; '/' for genres.
 - v2.9s - May  28th, 2016 - Fixed psxc-imdb not getting all data due to certain grep versions

--- a/scripts/psxc-imdb/CHANGELOG
+++ b/scripts/psxc-imdb/CHANGELOG
@@ -1,11 +1,12 @@
 PSXC-IMDB CHANGELOG:
 --------------------
-- v2.9v - Jan  03rd, 2020 - Get screens and ISLIMITED from Box Office Mojo (option USEBOM)
+- v2.9v - Feb  15th, 2020 - Get screens and ISLIMITED from Box Office Mojo (option USEBOM)
                           - Added option USEWIDEST to use "Widest Release" instead of "Opening" theaters
                           - Fixed PLOT and CAST, added PLOTWIDTH config option
                           - Added option to use Original Title instead of localized one (option USEORIGTITLE)
                           - Added option to USECURL and FLAGS for both curl and wget
                           - Fixed Businessdata (opening earnings in BUSINESSSHORT)
+                          - Fixed searching on iMDB.
 - v2.9u - Dec  26th, 2017 - Fix main and find for new layout, no user reviews and screens anymore.
 - v2.9t - Feb  13th, 2017 - Removed trailing '|' for languages, comments, countries, certs; '/' for genres.
 - v2.9s - May  28th, 2016 - Fixed psxc-imdb not getting all data due to certain grep versions

--- a/scripts/psxc-imdb/CHANGELOG
+++ b/scripts/psxc-imdb/CHANGELOG
@@ -1,5 +1,11 @@
 PSXC-IMDB CHANGELOG:
 --------------------
+- v2.9v - Jan  03rd, 2020 - Get screens and ISLIMITED from Box Office Mojo (option USEBOM)
+                          - Added option USEWIDEST to use "Widest Release" instead of "Opening" theaters
+                          - Fixed PLOT and CAST, added PLOTWIDTH config option
+                          - Added option to use Original Title instead of localized one (option USEORIGTITLE)
+                          - Added option to USECURL and FLAGS for both curl and wget
+                          - Fixed Businessdata (opening earnings in BUSINESSSHORT)
 - v2.9u - Dec  26th, 2017 - Fix main and find for new layout, no user reviews and screens anymore.
 - v2.9t - Feb  13th, 2017 - Removed trailing '|' for languages, comments, countries, certs; '/' for genres.
 - v2.9s - May  28th, 2016 - Fixed psxc-imdb not getting all data due to certain grep versions

--- a/scripts/psxc-imdb/UPGRADING
+++ b/scripts/psxc-imdb/UPGRADING
@@ -5,6 +5,16 @@ NOTE: If you use a different GLROOT than /glftpd, you most
       likely need to change a couple of variables in the files
       you replace.
 
+2.9u -> 2.9v - replace psxc-imdb.sh
+             --- new variables:
+             - psxc-imdb.conf: USEORIGTITLE
+             - psxc-imdb.conf: USEBOM
+             - psxc-imdb.conf: USEWIDEST
+             - psxc-imdb.conf: PLOTWIDTH
+             - psxc-imdb.conf: WGETFLAGS
+             - psxc-imdb.conf: USECURL
+             - psxc-imdb.conf: CURLFLAGS
+             - psxc-imdb.conf: PLOTWIDTH
 2.9t -> 2.9u - replace psxc-imdb.sh, psxc-imdb-find.sh
 2.9s -> 2.9t - replace psxc-imdb.sh
 2.9r -> 2.9s - replace psxc-imdb.sh, psxc-symlink-maker.sh

--- a/scripts/psxc-imdb/UPGRADING
+++ b/scripts/psxc-imdb/UPGRADING
@@ -5,7 +5,7 @@ NOTE: If you use a different GLROOT than /glftpd, you most
       likely need to change a couple of variables in the files
       you replace.
 
-2.9u -> 2.9v - replace psxc-imdb.sh, psxc-imdb-find.sh
+2.9u -> 2.9v - replace psxc-imdb.sh, psxc-imdb-find.sh, psxc-imdb-rescan.sh
              --- new variables:
              - psxc-imdb.conf: USEORIGTITLE
              - psxc-imdb.conf: USEBOM
@@ -14,7 +14,6 @@ NOTE: If you use a different GLROOT than /glftpd, you most
              - psxc-imdb.conf: WGETFLAGS
              - psxc-imdb.conf: USECURL
              - psxc-imdb.conf: CURLFLAGS
-             - psxc-imdb.conf: PLOTWIDTH
 2.9t -> 2.9u - replace psxc-imdb.sh, psxc-imdb-find.sh
 2.9s -> 2.9t - replace psxc-imdb.sh
 2.9r -> 2.9s - replace psxc-imdb.sh, psxc-symlink-maker.sh

--- a/scripts/psxc-imdb/UPGRADING
+++ b/scripts/psxc-imdb/UPGRADING
@@ -5,7 +5,7 @@ NOTE: If you use a different GLROOT than /glftpd, you most
       likely need to change a couple of variables in the files
       you replace.
 
-2.9u -> 2.9v - replace psxc-imdb.sh
+2.9u -> 2.9v - replace psxc-imdb.sh, psxc-imdb-find.sh
              --- new variables:
              - psxc-imdb.conf: USEORIGTITLE
              - psxc-imdb.conf: USEBOM

--- a/scripts/psxc-imdb/main/psxc-imdb.conf
+++ b/scripts/psxc-imdb/main/psxc-imdb.conf
@@ -338,7 +338,7 @@ SHOWCOMMENT=""
 IMDBWIDTH=77
 
 # Maximum width for Plot
-PLOTWIDTH=280
+PLOTWIDTH=275
 
 # head and tail written to DOTIMDB. Take notice of IMDBWITH - this should not be
 # wider than that. This output will be written as "echo -e" which means you can use

--- a/scripts/psxc-imdb/main/psxc-imdb.conf
+++ b/scripts/psxc-imdb/main/psxc-imdb.conf
@@ -154,7 +154,7 @@ CURLFLAGS=""
 # Allow the script to search for more generic imdb urls. This *may* lead to
 # false positives, but should not really cause any grief/false lookups.
 # Default is level 1 relaxation. 0 is *very* strict, 4 is most relaxed. If
-# you choose any level beyond 1, I would like to recieve the nfo's which
+# you choose any level beyond 1, I would like to receive the nfo's which
 # created false positives... So help me improve the routine and send the nfo's
 # my way ;) The FAQ has more info regarding the different levels.
 #RELAXEDURLS="1"     # "" is the same as "1"
@@ -176,7 +176,7 @@ SCANDIRS=""
 #LOCALURL="swedish"
 
 # When using post_check in glftpd.conf to start this script, it sometimes
-# does not recieve any arguments passed from glftpd. There is a way around this
+# doesn't receive any arguments passed from glftpd. There is a way around this
 # but it should only be used if imdb lookups done on releases fail on uploads,
 # but works when doing a rescan.
 # I'm not sure how many are affected by this bug, so feedback is appreciated.
@@ -208,7 +208,7 @@ TRIGGER="IMDB:"
 # README.psxc-imdb-find.
 # pzs-ng uses IMDBFIND - no need to change."
 FINDTRIGGER="IMDBFIND:"
-#FINDTRIGGER="IMDFINDVAR:"
+#FINDTRIGGER="IMDBFINDVAR:"
 
 # Date format used by bot. Edit according to your OS (FBSD/Linux is default)
 DATE=`date +"%a %b %d %H:%M:%S %Y"`

--- a/scripts/psxc-imdb/main/psxc-imdb.conf
+++ b/scripts/psxc-imdb/main/psxc-imdb.conf
@@ -104,6 +104,19 @@ USEPREMIERE="YES"
 USELIMITED="YES"
 #USELIMITED=""
 
+# Use Original Title instead of localized one? Note that this works
+# without setting any http headers or changing imdb account settings.
+USEORIGTITLE="YES"
+#USEORIGTITLE=""
+
+# Show Box Office Mojo screens? Will show number of theaters.
+USEBOM="YES"
+#USEBOM=""
+
+# Use "Widest Release" instead of "Opening" theaters.
+#USEWIDEST="YES"
+USEWIDEST=""
+
 # Lynx retries. This is helpful for those times lynx fails for some reason
 # to look up the imdb info.
 LYNXTRIES=3
@@ -119,13 +132,24 @@ LYNXTRIES=3
 # to get the data with the specified encoding (see CHARACTER_SET) or set
 # it to TRUE to only have ASCII. Using the -cfg flag with a file that doesn't
 # exist, is empty or doesn't have the setting, will be the same as FALSE.
+# To use a proxy: add "-cfg=lynx.cfg" and set http_proxy option in cfg file
 LYNXFLAGS="-dump -nolist -width=1000 -hiddenlinks=ignore -connect_timeout=10"
 #LYNXFLAGS="-dump -nolist -width=1000 -hiddenlinks=ignore -connect_timeout=10 -cfg=$GLROOT/etc/lynx.cfg"
 
 # To improve reliability even more, the use of wget can help. It's usage is
-# reccommended. Use "" to disable.
-USEWGET="YES"
+# recommended. Use "" to disable.
+#USEWGET="YES"
 #USEWGET=""
+# Wget flags used. To use a proxy here add:
+#   "-e use_proxy=yes -e http_proxy=127.0.0.1:3128"
+WGETFLAGS=""
+
+# Use cURL if wget is disabled. Use "" to disable.
+USECURL="YES"
+#USECURL=""
+# cURL flags used. To use a (socks) proxy add:
+#   "--socks5 127.0.0.1:1080" or "--http https://127.0.0.1:3218"
+CURLFLAGS=""
 
 # Allow the script to search for more generic imdb urls. This *may* lead to
 # false positives, but should not really cause any grief/false lookups.
@@ -147,11 +171,12 @@ SCANDIRS=""
 # url with info written in your language. For instance, to put "german.imdb.com"
 # in channel and the .imdb, set this variable to "german". The default is "" which
 # is equivalent to "us".
-LOCALURL=""
+# Note that you'll always get redirected to "https://imdb.com" nowadays
+#LOCALURL=""
 #LOCALURL="swedish"
 
 # When using post_check in glftpd.conf to start this script, it sometimes
-# doesn't receive any arguments passed from glftpd. There is a way around this
+# does not recieve any arguments passed from glftpd. There is a way around this
 # but it should only be used if imdb lookups done on releases fail on uploads,
 # but works when doing a rescan.
 # I'm not sure how many are affected by this bug, so feedback is appreciated.
@@ -253,6 +278,7 @@ FINDLOGFORMAT="MYOWN"
 # Please note that this variable is used by INFOFILENAME too (below).
 LIMITEDYES="limited"
 LIMITEDNO="not limited"
+#LIMITEDNO="wide"
 
 # Maximum number of cast members listed. Global setting.
 CASTNUM=5
@@ -286,6 +312,7 @@ RUNTIMENUM=99
 
 # The file to write imdb info to in the movie dir. Use "" to disable.
 DOTIMDB=".imdb"
+#DOTIMDB="imdb.nfo"
 #DOTIMDB=""
 
 # Someone requested a separate file for just the link, a <releasename>.imdb.url
@@ -309,6 +336,9 @@ SHOWCOMMENT=""
 # Maximum width for text written to DOTIMDB. This controls how many chars wide the
 # text should be before word-wrapping it.
 IMDBWIDTH=77
+
+# Maximum width for Plot
+PLOTWIDTH=280
 
 # head and tail written to DOTIMDB. Take notice of IMDBWITH - this should not be
 # wider than that. This output will be written as "echo -e" which means you can use
@@ -431,7 +461,7 @@ PRETRIGGER="PRE:"
 # is the 7th word in the line. Please note that text within '"' is counted as
 # one word, ie, there're 9 words in my example, not 10.
 #
-# To support f00-pre and others, you can now enter more than one number,
+# To support foo-pre and others, you can now enter more than one number,
 # separated by a space. With SEPARATOR set to "/" (see below), setting WORDS to
 # "4 3" with the following in glftpd.log:
 #

--- a/scripts/psxc-imdb/main/psxc-imdb.sh
+++ b/scripts/psxc-imdb/main/psxc-imdb.sh
@@ -117,7 +117,7 @@ if [ ! -z "$RECVDARGS" ]; then
    fi
 
 # Level 0 search
-   IMDBURLS="$(grep -a [Ii][Mm][Dd][Bb] $FILENAME | tr ' \|' '\n' | sed -n /[hH][tT][tT][pP]:[/][/].*[.][iI][mM][dD][bB][.].*.[0-9]/p | head -n 1 | tr -c -d '[:alnum:]\:./?')"
+   IMDBURLS="$(grep -a [Ii][Mm][Dd][Bb] $FILENAME | tr ' \|' '\n' | sed -n /[hH][tT][tT][pP][sS]*:[/][/].*[.][iI][mM][dD][bB][.].*.[0-9]/p | head -n 1 | tr -c -d '[:alnum:]\:./?')"
    if [ ! -z "$(echo $IMDBURLS | grep -a "imdb\.")" ]; then
 #    IMDBURL="https://www.imdb.com/title/tt""$(echo $IMDBURLS | sed "s/=/-/g" | sed "s/imdb./=/" | cut -d "=" -f 2 | cut -d "/" -f 2,3 | tr -c -d '[:digit:]')"
     IMDBURL="https://www.imdb.com/title/tt""$(echo $IMDBURLS | sed "s/=/-/g" | sed "s/imdb./=/" | cut -d "=" -f 2 |  grep -a -o "[0-9]*" | head -n 1)"
@@ -128,7 +128,7 @@ if [ ! -z "$RECVDARGS" ]; then
 
 # Level 1 search
    if [ -z "$IMDBURL" ] && [ $RELAXEDURLS -ge 1 ]; then
-    IMDBURLS="$(grep -a [Ii][Mm][Dd][Bb] $FILENAME | tr ' \|' '\n' | sed -n /[hH][tT][tT][pP]:[/][/].*[iI][mM][dD][bB][.].*.[0-9]/p | head -n 1 | tr -c -d '[:alnum:]\:./?')"
+    IMDBURLS="$(grep -a [Ii][Mm][Dd][Bb] $FILENAME | tr ' \|' '\n' | sed -n /[hH][tT][tT][pP][sS]*:[/][/].*[iI][mM][dD][bB][.].*.[0-9]/p | head -n 1 | tr -c -d '[:alnum:]\:./?')"
     if [ ! -z "$(echo $IMDBURLS | grep -a "imdb\.")" ]; then
      IMDBURL="https://www.imdb.com/title/tt""$(echo $IMDBURLS | sed "s/=/-/g" | sed "s/imdb./=/" | cut -d "=" -f 2 | cut -d "/" -f 2,3 | tr -c -d '[:digit:]')"
      if [ -z $(echo $IMDBURL | tr -cd '0-9') ]; then
@@ -273,7 +273,7 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
   DIRNAME=$(echo $DIRNAME | sed "s|\"\"|$SEPARATOR|g" | sed "s|\"||g")
   if [ -d $GLROOT$DIRNAME ]; then
    FILENAME=$(ls -1 $GLROOT$DIRNAME | grep -a "\.[Nn][Ff][Oo]$" | head -n 1)
-   IMDBURL="$(grep -a [Ii][Mm][Dd][Bb] $GLROOT$DIRNAME/$FILENAME | tr ' ' '\n' | sed -n /[hH][tT][tT][pP]:[/][/].*[.][iI][mM][dD][bB].*.[0-9]/p | head -n 1 | tr -c -d '[:alnum:]\:./?')"
+   IMDBURL="$(grep -a [Ii][Mm][Dd][Bb] $GLROOT$DIRNAME/$FILENAME | tr ' ' '\n' | sed -n /[hH][tT][tT][pP][sS]*:[/][/].*[.][iI][mM][dD][bB].*.[0-9]/p | head -n 1 | tr -c -d '[:alnum:]\:./?')"
    if [ ! -z "$(echo $IMDBURL | grep -a "\.imdb\.")" ]; then
     IMDBURL="https://www.imdb.com/title/tt""$(echo $IMDBURL | sed "s/=/-/g" | sed "s/.imdb./=/" | cut -d "=" -f 2 | cut -d "/" -f 2,3 | tr -c -d '[:digit:]')"
    fi

--- a/scripts/psxc-imdb/main/psxc-imdb.sh
+++ b/scripts/psxc-imdb/main/psxc-imdb.sh
@@ -15,7 +15,7 @@ CONFFILE=/etc/psxc-imdb.conf
 ###################
 
 # version number. do not change.
-VERSION="v2.9u"
+VERSION="v2.9v"
 
 ######################################################################################################
 
@@ -119,8 +119,8 @@ if [ ! -z "$RECVDARGS" ]; then
 # Level 0 search
    IMDBURLS="$(grep -a [Ii][Mm][Dd][Bb] $FILENAME | tr ' \|' '\n' | sed -n /[hH][tT][tT][pP]:[/][/].*[.][iI][mM][dD][bB][.].*.[0-9]/p | head -n 1 | tr -c -d '[:alnum:]\:./?')"
    if [ ! -z "$(echo $IMDBURLS | grep -a "imdb\.")" ]; then
-#    IMDBURL="http://www.imdb.com/title/tt""$(echo $IMDBURLS | sed "s/=/-/g" | sed "s/imdb./=/" | cut -d "=" -f 2 | cut -d "/" -f 2,3 | tr -c -d '[:digit:]')"
-    IMDBURL="http://www.imdb.com/title/tt""$(echo $IMDBURLS | sed "s/=/-/g" | sed "s/imdb./=/" | cut -d "=" -f 2 |  grep -a -o "[0-9]*" | head -n 1)"
+#    IMDBURL="https://www.imdb.com/title/tt""$(echo $IMDBURLS | sed "s/=/-/g" | sed "s/imdb./=/" | cut -d "=" -f 2 | cut -d "/" -f 2,3 | tr -c -d '[:digit:]')"
+    IMDBURL="https://www.imdb.com/title/tt""$(echo $IMDBURLS | sed "s/=/-/g" | sed "s/imdb./=/" | cut -d "=" -f 2 |  grep -a -o "[0-9]*" | head -n 1)"
     if [ -z $(echo $IMDBURL | tr -cd '0-9') ]; then
      IMDBURL=""
     fi
@@ -130,7 +130,7 @@ if [ ! -z "$RECVDARGS" ]; then
    if [ -z "$IMDBURL" ] && [ $RELAXEDURLS -ge 1 ]; then
     IMDBURLS="$(grep -a [Ii][Mm][Dd][Bb] $FILENAME | tr ' \|' '\n' | sed -n /[hH][tT][tT][pP]:[/][/].*[iI][mM][dD][bB][.].*.[0-9]/p | head -n 1 | tr -c -d '[:alnum:]\:./?')"
     if [ ! -z "$(echo $IMDBURLS | grep -a "imdb\.")" ]; then
-     IMDBURL="http://www.imdb.com/title/tt""$(echo $IMDBURLS | sed "s/=/-/g" | sed "s/imdb./=/" | cut -d "=" -f 2 | cut -d "/" -f 2,3 | tr -c -d '[:digit:]')"
+     IMDBURL="https://www.imdb.com/title/tt""$(echo $IMDBURLS | sed "s/=/-/g" | sed "s/imdb./=/" | cut -d "=" -f 2 | cut -d "/" -f 2,3 | tr -c -d '[:digit:]')"
      if [ -z $(echo $IMDBURL | tr -cd '0-9') ]; then
       IMDBURL=""
      fi
@@ -141,7 +141,7 @@ if [ ! -z "$RECVDARGS" ]; then
    if [ -z "$IMDBURL" ] && [ $RELAXEDURLS -ge 2 ]; then
     IMDBURLS="$(grep -a [Ii][Mm][Dd][Bb] $FILENAME | tr ' \|' '\n' | sed -n /.*[iI][mM][dD][bB][.].*.[0-9]/p | head -n 1 | tr -c -d '[:alnum:]\:./?')"
     if [ ! -z "$(echo $IMDBURLS | grep -a "imdb\.")" ]; then
-     IMDBURL="http://www.imdb.com/title/tt""$(echo $IMDBURLS | sed "s/=/-/g" | sed "s/imdb./=/" | cut -d "=" -f 2 | cut -d "/" -f 2,3 | tr -c -d '[:digit:]')"
+     IMDBURL="https://www.imdb.com/title/tt""$(echo $IMDBURLS | sed "s/=/-/g" | sed "s/imdb./=/" | cut -d "=" -f 2 | cut -d "/" -f 2,3 | tr -c -d '[:digit:]')"
      if [ -z $(echo $IMDBURL | tr -cd '0-9') ]; then
       IMDBURL=""
      fi
@@ -159,7 +159,7 @@ if [ ! -z "$RECVDARGS" ]; then
      fi
     done
     if [ ! -z "$IMDBURL" ]; then
-     IMDBURL="http://www.imdb.com/title/tt""$IMDBURL"
+     IMDBURL="https://www.imdb.com/title/tt""$IMDBURL"
     fi
    fi
 
@@ -172,7 +172,7 @@ if [ ! -z "$RECVDARGS" ]; then
      fi
     done
     if [ ! -z "$IMDBURL" ]; then
-     IMDBURL="http://www.imdb.com/title/tt""$IMDBURL"
+     IMDBURL="https://www.imdb.com/title/tt""$IMDBURL"
     fi
    fi
 
@@ -275,7 +275,7 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
    FILENAME=$(ls -1 $GLROOT$DIRNAME | grep -a "\.[Nn][Ff][Oo]$" | head -n 1)
    IMDBURL="$(grep -a [Ii][Mm][Dd][Bb] $GLROOT$DIRNAME/$FILENAME | tr ' ' '\n' | sed -n /[hH][tT][tT][pP]:[/][/].*[.][iI][mM][dD][bB].*.[0-9]/p | head -n 1 | tr -c -d '[:alnum:]\:./?')"
    if [ ! -z "$(echo $IMDBURL | grep -a "\.imdb\.")" ]; then
-    IMDBURL="http://www.imdb.com/title/tt""$(echo $IMDBURL | sed "s/=/-/g" | sed "s/.imdb./=/" | cut -d "=" -f 2 | cut -d "/" -f 2,3 | tr -c -d '[:digit:]')"
+    IMDBURL="https://www.imdb.com/title/tt""$(echo $IMDBURL | sed "s/=/-/g" | sed "s/.imdb./=/" | cut -d "=" -f 2 | cut -d "/" -f 2,3 | tr -c -d '[:digit:]')"
    fi
    if [ ! -z "$IMDBURL" ]; then
     a="$(tail -n 5 $GLLOG | grep -a "$TRIGGER" | grep -a "$DIRNAME" | tail -n 1)"
@@ -460,8 +460,8 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
     let OUTPUTTRIES=OUTPUTTRIES+1
     OUTPUTOK="OK"
     while [ $LYNXTRIES -gt 0 ]; do
-     if [ -z "$USEWGET" ]; then
-      lynx $LYNXFLAGS $IMDBURL/reference | grep -a -v "^$" | tr '\t' ' ' | tr -s ' ' | tr '\n' '~' | sed "s/\.\.\.~ /... /g" | tr '~' '\n' > $TMPFILE 2>&1
+     if [ -z "$USEWGET" ] && [ -z "$USECURL" ]; then
+     lynx $LYNXFLAGS $IMDBURL/reference | grep -a -v "^$" | tr '\t' ' ' | tr -s ' ' | tr '\n' '~' | sed "s/\.\.\.~ /... /g" | tr '~' '\n' | sed 's/*/\\\*/' > $TMPFILE 2>&1
       if [ $? = "0" ]; then
        LYNXTRIES=$LYNXTRIESORIG
        break
@@ -470,13 +470,17 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
        sleep 1
       fi
      else
-      #http_proxy=192.168.0.1:8080
-      wget -U "Internet Explorer" -O $TMPFILE --timeout=30 $IMDBURL/combined >/dev/null 2>&1
+      if [ ! -z "$USEWGET" ]; then
+       #http_proxy=192.168.0.1:8080
+       wget $WGETFLAGS -U "Internet Explorer" -O $TMPFILE --timeout=30 $IMDBURL/reference >/dev/null 2>&1
+      elif [ ! -z "$USECURL" ]; then
+       curl $CURLFLAGS -A "Internet Explorer" -o $TMPFILE --connect-timeout 30 $IMDBURL/reference >/dev/null 2>&1
+      fi
       if [ $? = "0" ] || [ -z "$(cat $TMPFILE)" ]; then
        TMBURL=$(grep -a "\.jpg" $TMPFILE | head -n 1 | tr ' \"' '\n' | grep -a "\.jpg" | head -n 1)
        LYNXTRIES=$LYNXTRIESORIG
        HTMLPAGE="$(lynx $LYNXFLAGS -force_html $TMPFILE)"
-       echo "$HTMLPAGE" | grep -a -v "^$" | tr '\t' ' ' | tr -s ' ' | tr '\n' '~' | sed "s/:~ /: /g" | tr '~' '\n' > $TMPFILE
+       echo "$HTMLPAGE" | grep -a -v "^$" | tr '\t' ' ' | tr -s ' ' | tr '\n' '~' | sed "s/\.\.\.~ /... /g" | tr '~' '\n' | sed 's/*/\\\*/' > $TMPFILE 2>&1
        break
       else
        let LYNXTRIES=LYNXTRIES-1
@@ -496,6 +500,7 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
      OUTPUTOK=""
      break
     fi
+    ORIGTITLE=$(grep -a -i "^.* (original title)$" "$TMPFILE" | head -n 1 | sed s/\"/$QUOTECHAR/g )
 
 # Grab hold of the info we'll use later. Also do some formatting.
 #################################################################
@@ -507,9 +512,13 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
      OUTPUTOK=""
      break
     fi
-    GENRE="Genre........: $(sed -n '/^ Genres$/,/^ [^ *]/p' "$TMPFILE" | sed -n 's/^ \* //p' | sed s/\"/$QUOTECHAR/g | sed '/^ *$/d' | head -n $GENRENUM | tr '\n' '/' | sed "s/[ /]*$//")"
+    if [ ! -z "$USEORIGTITLE" ] && [ ! -z "$ORIGTITLE" ]; then
+     TITLENAME="$( echo $ORIGTITLE | sed -e 's/^ *//g' -e 's/ (original title)//' )"
+     TITLE="$TITLENAME $TITLEYEAR"
+    fi
+    GENRE="Genre........: $(sed -n '/^ Genres$/,/^ [^ \*]/p' "$TMPFILE" | sed -n 's/^ \\\* //p' | sed s/\"/$QUOTECHAR/g | sed '/^ \*$/d' | head -n $GENRENUM | tr '\n' '/' | sed "s/[ /]*$//")"
     GENRECLEAN=$(echo $GENRE | sed "s/Genre........: *//")
-    RATING="User Rating..: $(grep -a " \* [0-9][0-9]*\(\.[0-9]\)* (\([0-9]*,\)*[0-9][0-9]*)" "$TMPFILE" | sed "s/^ \* //" | sed s/\"/$QUOTECHAR/g)"
+    RATING="User Rating..: $(grep -a " \\\\\* [0-9][0-9]*\(\.[0-9]\)* (\([0-9]*,\)*[0-9][0-9]*)" "$TMPFILE" | sed "s/^ \\\\\* //" | sed s/\"/$QUOTECHAR/g)"
     if [ "$RATING" = "User Rating..: 0 (0)" ]; then
       RATING="User Rating..: Awaiting 5 votes"
     fi
@@ -541,22 +550,30 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
     if [ ! -z "$BOTTOM" ]; then
       RATINGCLEAN="$(echo "$RATINGCLEAN Bottom 100: #$BOTTOM")"
     fi
-    COUNTRY="Country......: $(sed -n '/^ Country$/,/^ [^ *]/p' "$TMPFILE" | sed -n 's/^ \* //p' | sed s/\"/$QUOTECHAR/g | sed '/^ *$/d' | head -n $COUNTRYNUM | tr '\n' '/' | sed "s/[ /]*$//")"
+    COUNTRY="Country......: $(sed -n '/^ Country$/,/^ [^ *]/p' "$TMPFILE" | sed -n 's/^ \\\* //p' | sed s/\"/$QUOTECHAR/g | sed '/^ *$/d' | head -n $COUNTRYNUM | tr '\n' '/' | sed "s/[ /]*$//")"
     COUNTRYCLEAN=$(echo $COUNTRY | sed "s/Country......: *//")
     TAGLINE="Tagline......: $(sed -n 's/^ Taglines //p' "$TMPFILE" | sed "s/ See more ..*//" | sed s/\"/$QUOTECHAR/g | head -n 1)"
     TAGLINECLEAN=$(echo $TAGLINE | sed "s/Tagline......: *//")
-    LANGUAGE="Language.....: $(sed -n '/^ Language$/,/^ [^ *]/p' "$TMPFILE" | sed -n 's/^ \* //p' | sed s/\"/$QUOTECHAR/g | head -n $LANGUAGENUM | tr '\n' '/' | sed "s/[ /]*$//")"
+    LANGUAGE="Language.....: $(sed -n '/^ Language$/,/^ [^ *]/p' "$TMPFILE" | sed -n 's/^ \\\* //p' | sed s/\"/$QUOTECHAR/g | head -n $LANGUAGENUM | tr '\n' '/' | sed "s/[ /]*$//")"
     LANGUAGECLEAN=$(echo $LANGUAGE | sed "s/Language.....: *//")
-    PLOT="Plot: $(sed -n '/^ Plot Summary$/,/^ \* Plot Summary$/p' "$TMPFILE" | sed -n 'n;p' | sed s/\"/$QUOTECHAR/g | sed 's/^\ *//g' | tr -s ' ' | sed "s/ *$//")"
+    # Yeah, this keeps getting worse ;)
+    if [ -z $PLOTWIDTH ]; then
+      PLOTWIDTH=275
+    fi
+    PLOT="Plot: "$(sed -n '/^ Plot Summary$/,/\(^ \\\* Plot \(Summary\|Synopsis\)\|Plot Keywords\)$/{//d;p;}' "$TMPFILE" | \
+                   sed -e 's/\( \\\* Plot Summary\|Written by .*\)$//' -e '/(.*@.*)/d' | \
+                   sed s/\"/$QUOTECHAR/g | sed 's/^\ *//g' | tr -s ' ' | sed "s/ *$//" | \
+                   fold -s -w $PLOTWIDTH | sed ':a;N;$!ba;s/\n/\\\\n/g' | sed 's/\(.\{1000\}\).*/\1.../' | grep ^[0-9A-Za-z])""
     PLOTCLEAN=$(echo $PLOT | sed "s/Plot: *//")
     if [ ! -z "$(echo "$PLOTCLEAN" | grep -a -e "\(\ \)\ \(\ \)")" ]; then
      OUTPUTOK=""
      break
     fi
-    CERT="Certification: $(sed -n '/^ Certification$/,/^[^ *]/p' "$TMPFILE" | sed -n 's/^ \* //p' | sed s/\"/$QUOTECHAR/g | head -n $CERTIFICATIONNUM | tr '\n' '/' | sed "s/[ /]*$//")"
+    CERT="Certification: $(sed -n '/^ Certification$/,/^[^ *]/p' "$TMPFILE" | sed -n 's/^ \\\* //p' | sed s/\"/$QUOTECHAR/g | head -n $CERTIFICATIONNUM | tr '\n' '/' | sed "s/[ /]*$//")"
     CERTCLEAN=$(echo $CERT | sed "s/Certification: *//" | tr '/' '\n' | grep -a -e "United States:" | tr -d ' ' | tail -n 1)
     # We get the name twice (due to the image alt-text) so need to remove by counting spaces
-    CASTRAW=$(sed 's/^ Rest of cast listed alphabetically:/Cast verified as complete\n/' "$TMPFILE" | sed -n '/^Cast verified as complete$/,/^[^ ]/p' | sed '/^Cast verified as complete$/d;/^ Edit$/d' | sed -n 's/^ //p' | head -n $CASTNUM)
+    CASTRAW=$(sed -E -n '/^(Cast|Cast verified as complete|Complete, Cast awaiting verification)$/,/^(Directed|Written) by$/{//d;p;}' $TMPFILE | \
+              sed -E '/^ (Edit|Rest of cast listed alphabetically:)/d' | sed -n 's/^ //p' | head -n $CASTNUM)
     CAST=""
     OLDIFS=$IFS
     IFS="
@@ -564,7 +581,7 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
      # Need newline above so keep " there.
     for CASTN in $CASTRAW; do
      CASTNC=$(echo "$CASTN" | sed 's/ \.\.\..*//' | tr ' ' '\n' | wc -l)
-     CASTNC=$((CASTNC / 2 + 1))
+     CASTNC=$(((CASTNC / 2) + 1))
      CAST="$CAST$(echo $CASTN | cut -d' ' -f$CASTNC- | sed s/\"/$QUOTECHAR/g)
 "
      # Need newline above so keep " there.
@@ -579,7 +596,7 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
     COMMENTSHORTCLEAN=$(echo $COMMENTSHORT | sed "s/User Reviews: *//")
     COMMENT="Not supported anymore"
     [[ -n "$COMMENT" ]] && COMMENTCLEAN=$(echo "$COMMENT" | sed "s/^\ *//g" | sed "s/\ *$//g" | sed s/\{\}\"/$QUOTECHAR/g | tr '\n' '|' | sed "s/[ /]*$//")
-    RUNTIME="Runtime......: $(sed -n '/^ Runtime$/,/^ [^ *]/p' "$TMPFILE" | sed -n 's/^ \* //p' | sed s/\"/$QUOTECHAR/g | sed '/^ *$/d' | head -n $RUNTIMENUM | tr '\n' '/' | sed "s/[ /]*$//")"
+    RUNTIME="Runtime......: $(sed -n '/^ Runtime$/,/^ [^ *]/p' "$TMPFILE" | sed -n 's/^ \\\* //p' | sed s/\"/$QUOTECHAR/g | sed '/^ *$/d' | head -n $RUNTIMENUM | tr '\n' '/' | sed "s/[ /]*$//")"
     RUNTIMECLEAN="$(echo $RUNTIME | sed "s/Runtime......: *//" | tr '/ ' '\n' | sed -e /^$/d | head -n 1 | tr -c -d '[:digit:]')"
     if [ ! -z "$RUNTIMECLEAN" ]; then
      RUNTIMECLEAN="$RUNTIMECLEAN min"
@@ -627,12 +644,12 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
 
 # We won't check business and release as closely right away... may do so later
 ##############################################################################
-   BUSINESSURL="$IMDBURL" # Page has become imdbpro, need to parse from main page
+   BUSINESSURL="${IMDBURL}/" # Page has become imdbpro, need to parse from main page
    RELEASEURL="$(echo "$IMDBURL""/releaseinfo" | tr -s '/' | sed "s|:/|://|")"
    if [ ! -z "$USEBUSINESS" ]; then
     while [ $LYNXTRIES -gt 0 ]; do
-     if [ -z "$USEWGET" ]; then
-      lynx $LYNXFLAGS $BUSINESSURL | grep -a -v "^$" | tr '\t' ' ' | tr -s ' ' | tr '\n' '~' | sed "s/:~ /: /g" | tr '~' '\n' > $TMPFILE 2>&1
+     if [ -z "$USEWGET" ] && [ -z "$USECURL" ]; then
+      lynx $LYNXFLAGS $BUSINESSURL | grep -a -v "^$" | tr '\t' ' ' | tr -s ' ' | tr '\n' '~' | sed "s/:~ /: /g" | tr '~' '\n' | sed 's/*/\\\*/'> $TMPFILE 2>&1
       if [ $? = "0" ]; then
        LYNXTRIES=$LYNXTRIESORIG
        break
@@ -641,12 +658,16 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
        sleep 1
       fi
      else
-      #http_proxy=192.168.0.1:8080
-      wget -U "Internet Explorer" -O $TMPFILE --timeout=30 $BUSINESSURL >/dev/null 2>&1
+      if [ ! -z "$USEWGET" ]; then
+       #http_proxy=192.168.0.1:8080
+       wget $WGETFLAGS -U "Internet Explorer" -O $TMPFILE --timeout=30 $BUSINESSURL >/dev/null 2>&1
+      elif [ ! -z "$USECURL" ]; then
+       curl $CURLFLAGS -A "Internet Explorer" -o $TMPFILE --connect-timeout 30 $BUSINESSURL >/dev/null 2>&1
+      fi
       if [ $? = "0" ] || [ -z "$(cat $TMPFILE)" ]; then
        LYNXTRIES=$LYNXTRIESORIG
        HTMLPAGE="$(lynx $LYNXFLAGS -force_html $TMPFILE)"
-       echo "$HTMLPAGE" | grep -a -v "^$" | tr '\t' ' ' | tr -s ' ' | tr '\n' '~' | sed "s/:~ /: /g" | tr '~' '\n' > $TMPFILE
+       echo "$HTMLPAGE" | grep -a -v "^$" | tr '\t' ' ' | tr -s ' ' | tr '\n' '~' | sed "s/:~ /: /g" | tr '~' '\n' | sed 's/*/\\\*/' > $TMPFILE
        break
       else
        let LYNXTRIES=LYNXTRIES-1
@@ -660,46 +681,21 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
      ISLIMITED=""
      [[ -n "$(echo "$BUSINESS" | grep -a "^Opening Weekend.* Limited Release$")" ]] && ISLIMITED="$LIMITEDYES"
      [[ -n "$(echo "$BUSINESS" | grep -a "^Opening Weekend.* Wide Release$")" ]] && ISLIMITED="$LIMITEDNO"
-     # IMDBPro only
+     # IMDBPro only, replaced by BOM below (where possible)
      BUSINESSSHORT=""
      BUSINESSSCREENS=""
-     #BUSINESSSHORTUSA=$(echo "$BUSINESS" | grep -a -e "[Ss][Cc][Rr][Ee][Ee][Nn]" | grep -a -e "([Uu][Ss][Aa])" | tail -n 1)
-     #BUSINESSSHORTUK=$(echo "$BUSINESS" | grep -a -e "[Ss][Cc][Rr][Ee][Ee][Nn]" | grep -a -e "([Uu][Kk])" | tail -n 1)
-     #[[ -z "$BUSINESSSHORTUSA" ]] && BUSINESSSHORTUSA=$(echo "$BUSINESS" | grep -a -e "([Uu][Ss][Aa])" | tail -n 1)
-     #[[ -z "$BUSINESSSHORTUK" ]] && BUSINESSSHORTUK=$(echo "$BUSINESS" | grep -a -e "([Uu][Kk])" | tail -n 1)
-     #if [ -z "$BUSINESSSHORTUSA" ] && [ -z "$BUSINESSSHORTUK" ]; then
-     # BUSINESSSHORT=$(echo "$BUSINESS" | tail -n 1)
-     #elif [ -z "$BUSINESSSHORTUSA" ]; then
-     # BUSINESSSHORT="$BUSINESSSHORTUK"
-     #else
-     # BUSINESSSHORT="$BUSINESSSHORTUSA"
-     #fi
-     #BUSINESSSCREENSUSA=$(echo "$BUSINESSSHORTUSA" | tr '()' '\n' | grep -a -e "[Ss][Cc][Rr][Ee][Ee][Nn]" | tr ' ' '\n' | head -n 1 | tr -d ',')
-     #BUSINESSSCREENSUK=$(echo "$BUSINESSSHORTUK" | tr '()' '\n' | grep -a -e "[Ss][Cc][Rr][Ee][Ee][Nn]" | tr ' ' '\n' | head -n 1 | tr -d ',')
-     #BUSINESSSCREENS=$(echo "$BUSINESSSHORT" | tr '()' '\n' | grep -a -e "[Ss][Cc][Rr][Ee][Ee][Nn]" | tr ' ' '\n' | head -n 1)
-     #if [ ! -z "$BUSINESSSCREENSUSA" ]; then
-     # if [ $BUSINESSSCREENSUSA -lt 500 ]; then
-     #  ISLIMITED=$LIMITEDYES
-     # else
-     #  ISLIMITED=$LIMITEDNO
-     # fi
-     #else
-     # ISLIMITED=""
-     #fi
-     #if [ ! -z "$BUSINESSSCREENSUK" ] && [[ -z "$ISLIMITED" || "x$ISLIMITED" == "x$LIMITEDYES" ]]; then
-     # if [ $BUSINESSSCREENSUK -lt 300 ]; then
-     #  ISLIMITED=$LIMITEDYES
-     # else
-     #  ISLIMITED=$LIMITEDNO
-     #  BUSINESSSHORT=$BUSINESSSHORTUK
-     #  BUSINESSSCREENS=$BUSINESSSCREENSUK
-     # fi
-     #fi
+     BUSINESSSHORTUSA=$( echo "$BUSINESS" | sed -n -E 's/^Opening Weekend (USA|United States): ([0-9,$]+), ([0-9]{1,2}) ([A-Z][a-z][a-z])[a-z]* ([0-9]{4})/\2 \3 \4 \5/p' )
+     BUSINESSSHORTUK=$( echo "$BUSINESS" | sed -n -E 's/^Opening Weekend (UK|United Kingdom): ([0-9,$]+), ([0-9]{1,2}) ([A-Z][a-z][a-z])[a-z]* ([0-9]{4})/\2 \3 \4 \5/p' )
+     if [ -z "$BUSINESSSHORTUSA" ]; then
+      BUSINESSSHORT="$BUSINESSSHORTUK"
+     else
+      BUSINESSSHORT="$BUSINESSSHORTUSA"
+     fi
     fi
    fi
    if [ ! -z "$USEPREMIERE" ] || [ ! -z "$USELIMITED" ]; then
     while [ $LYNXTRIES -gt 0 ]; do
-     if [ -z "$USEWGET" ]; then
+     if [ -z "$USEWGET" ] && [ -z "$USECURL" ]; then
       lynx $LYNXFLAGS $RELEASEURL | grep -a -v "^$" | tr '\t' ' ' | tr -s ' ' | tr '\n' '~' | sed "s/:~ /: /g" | tr '~' '\n' > $TMPFILE 2>&1
       if [ $? = "0" ]; then
        LYNXTRIES=$LYNXTRIESORIG
@@ -709,12 +705,16 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
        sleep 1
       fi
      else
-      #http_proxy=192.168.0.1:8080
-      wget -U "Internet Explorer" -O $TMPFILE --timeout=30 $RELEASEURL >/dev/null 2>&1
+      if [ ! -z "$USEWGET" ]; then
+       #http_proxy=192.168.0.1:8080
+       wget $WGETFLAGS -U "Internet Explorer" -O $TMPFILE --timeout=30 $RELEASEURL >/dev/null 2>&1
+      elif [ ! -z "$USECURL" ]; then
+       curl $CURLFLAGS -A "Internet Explorer" -o $TMPFILE --connect-timeout 30 $RELEASEURL >/dev/null 2>&1
+      fi
       if [ $? = "0" ] || [ -z "$(cat $TMPFILE)" ]; then
        LYNXTRIES=$LYNXTRIESORIG
        HTMLPAGE="$(lynx $LYNXFLAGS -force_html $TMPFILE)"
-       echo "$HTMLPAGE" | grep -a -v "^$" | tr '\t' ' ' | tr -s ' ' | tr '\n' '~' | sed "s/:~ /: /g" | tr '~' '\n' > $TMPFILE
+       echo "$HTMLPAGE" | grep -a -v "^$" | tr '\t' ' ' | tr -s ' ' | tr '\n' '~' | sed "s/:~ /: /g" | tr '~' '\n' | sed 's/*/\\\*/' > $TMPFILE
        break
       else
        let LYNXTRIES=LYNXTRIES-1
@@ -737,6 +737,118 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
       LIMITED=$(grep -a -e "(limited)" "$TMPFILE" | head -n 1 | sed "s/ (limited)//" | sed "s/^\ *//g" | sed "s/\ *$//g" | tr -s ' ' | sed s/\"/$QUOTECHAR/g)
      fi
     fi
+   fi
+
+# Get screens/islimited from parsing Box Office Mojo page (source: slftp) 
+##############################################################################
+
+   if [ ! -z "$USEBOM" ]; then
+    BOMURL="https://www.boxofficemojo.com/title/$(echo "$IMDBURL" | grep -Pow "tt[0-9]+")/"
+    while [ $LYNXTRIES -gt 0 ]; do
+     if [ -z "$USEWGET" ] && [ -z "$USECURL" ]; then
+      lynx -source $LYNXFLAGS $BOMURL > $TMPFILE 2>&1
+      if [ $? = "0" ]; then
+       LYNXTRIES=$LYNXTRIESORIG
+       break
+      else
+       let LYNXTRIES=LYNXTRIES-1
+       sleep 1
+      fi
+     else
+      if [ ! -z "$USEWGET" ]; then
+       #http_proxy=192.168.0.1:8080
+       wget $WGETFLAGS -U "Internet Explorer" -O $TMPFILE --timeout=30 $BOMURL >/dev/null 2>&1
+      elif [ ! -z "$USECURL" ]; then
+       curl $CURLFLAGS -A "Internet Explorer" -o $TMPFILE --connect-timeout 30 $BOMURL >/dev/null 2>&1
+      fi
+      if [ $? = "0" ] || [ -z "$(cat $TMPFILE)" ]; then
+       LYNXTRIES=$LYNXTRIESORIG
+       break
+      else
+       let LYNXTRIES=LYNXTRIES-1
+       echo -n "" > $TMPFILE
+       sleep 1
+      fi
+     fi
+    done
+    BOMRELEASEGROUP="$(sed -n -E 's|.*<option value="(/releasegroup/gr[0-9]+/)">Original Release</option>.*|\1|p' $TMPFILE)"
+    BOMURLRELEASEGROUP="https://www.boxofficemojo.com${BOMRELEASEGROUP}"
+    while [ $LYNXTRIES -gt 0 ]; do
+     if [ -z "$USEWGET" ] && [ -z "$USECURL" ]; then
+      lynx -source $LYNXFLAGS $BOMURLRELEASEGROUP > $TMPFILE 2>&1
+      if [ $? = "0" ]; then
+       LYNXTRIES=$LYNXTRIESORIG
+       break
+      else
+       let LYNXTRIES=LYNXTRIES-1
+       sleep 1
+      fi
+     else
+      if [ ! -z "$USEWGET" ]; then
+       #http_proxy=192.168.0.1:8080
+       wget $WGETFLAGS -U "Internet Explorer" -O $TMPFILE --timeout=30 $BOMURLRELEASEGROUP >/dev/null 2>&1
+      elif [ ! -z "$USECURL" ]; then
+       curl $CURLFLAGS -A "Internet Explorer" -o $TMPFILE --connect-timeout 30 $BOMURLRELEASEGROUP >/dev/null 2>&1
+      fi
+      if [ $? = "0" ] || [ -z "$(cat $TMPFILE)" ]; then
+       LYNXTRIES=$LYNXTRIESORIG
+       break
+      else
+       let LYNXTRIES=LYNXTRIES-1
+       echo -n "" > $TMPFILE
+       sleep 1
+      fi
+     fi
+    done
+    BOMRELEASE="$(sed -n -E 's|.*<a class="a-link-normal" href="(/release/rl[0-9]+/)[^\"]*">Domestic[^\n]*</a>.*|\1|p' $TMPFILE | head -n 1)"
+    BOMURLRELEASE="https://www.boxofficemojo.com${BOMRELEASE}"
+    while [ $LYNXTRIES -gt 0 ]; do
+     if [ -z "$USEWGET" ] && [ -z "$USECURL" ]; then
+      #lynx $LYNXFLAGS $BOMURLRELEASE | grep -a -v "^$" | tr '\t' ' ' | tr -s ' ' | tr '\n' '~' | sed "s/:~ /: /g" | tr '~' '\n' | sed 's/*/\\\*/' > $TMPFILE 2>&1
+      lynx -source $LYNXFLAGS $BOMURLRELEASE > $TMPFILE 2>&1
+      if [ $? = "0" ]; then
+       LYNXTRIES=$LYNXTRIESORIG
+       break
+      else
+       let LYNXTRIES=LYNXTRIES-1
+       sleep 1
+      fi
+     else
+      if [ ! -z "$USEWGET" ]; then
+       #http_proxy=192.168.0.1:8080
+       wget $WGETFLAGS -U "Internet Explorer" -O $TMPFILE --timeout=30 $BOMURLRELEASE >/dev/null 2>&1
+      elif [ ! -z "$USECURL" ]; then
+       curl $CURLFLAGS -A "Internet Explorer" -o $TMPFILE --connect-timeout 30 $BOMURLRELEASE >/dev/null 2>&1
+      fi
+      if [ $? = "0" ] || [ -z "$(cat $TMPFILE)" ]; then
+       LYNXTRIES=$LYNXTRIESORIG
+       break
+      else
+       let LYNXTRIES=LYNXTRIES-1
+       echo -n "" > $TMPFILE
+       sleep 1
+      fi
+     fi
+    done
+    if [ "$LYNXTRIES" = "$LYNXTRIESORIG" ]; then
+     if [ ! -z "$USEWIDEST" ]; then
+      BUSINESSSCREENS="$(sed -n -E 's|.*<div[^>]*><span>Widest Release</span><span>([0-9,]+) theaters</span></div>.*|\1|p' $TMPFILE | head -n1 | tr -d ',' )"
+     else 
+      BUSINESSSCREENS=$(sed -n -E 's|.*<div[^>]*><span>Opening</span><span><span class="money">[0-9,$]+</span><br/>*([0-9,]+)$|\1|p' $TMPFILE | head -n1 | tr -d ',' )
+     fi
+     if [ -z "$(echo "$BUSINESSSCREENS" | tr -cd '0-9')" ]; then
+      BUSINESSSCREENS=""
+     fi
+     if [ ! -z "$BUSINESSSCREENS" ] && [ -z "$ISLIMITED" ]; then
+      if [ $BUSINESSSCREENS -lt 500 ]; then
+       ISLIMITED=$LIMITEDYES
+      else
+       ISLIMITED=$LIMITEDNO
+      fi
+     else
+      ISLIMITED=""
+     fi
+    fi 
    fi
    if [ ! -z "$IMDBHEAD" ]; then
     BOTHEAD=$(echo $BOTHEADORIG | sed "s/RELEASENAME/$BOLD$IMDBDIR$BOLD/")
@@ -895,7 +1007,8 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
     fi
     if [ ! -z "$PLOT" ]; then
      echo "-" >> "$IMDBLNK"
-     echo "$PLOT" | fold -s -w $IMDBWIDTH >> "$IMDBLNK"
+     #echo "$PLOT" | fold -s -w $IMDBWIDTH >> "$IMDBLNK"
+     echo "$PLOT" | sed 's/\\\\n//g' | fold -s -w $IMDBWIDTH >> "$IMDBLNK"
     fi
     if [ ! -z "$SHOWCOMMENT" ] && [ ! -z "$COMMENT" ]; then
      echo "---" >> "$IMDBLNK"
@@ -950,7 +1063,11 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
    if [ "$DOWNLOADTHUMB" = "YES" ]; then
     FILENAME=$(ls -1Ftr "$GLROOT$IMDBLKL" | grep -a -v "/" | grep -a -v "@" | grep -a -e "[.][nN][fF][oO]" | head -n 1)
     TMBNAME=$(echo $FILENAME | sed "s/\.nfo/.jpg/")
-    wget -U "Internet Explorer" -O $GLROOT$IMDBLKL/$TMBNAME --timeout=30 $TMBURL >/dev/null 2>&1
+    if [ ! -z "$USEWGET" ]; then
+     wget $WGETFLAGS -U "Internet Explorer" -O $TMPFILE --timeout=30 $GLROOT$IMDBLKL/$TMBNAME >/dev/null 2>&1
+    elif [ ! -z "$USECURL" ]; then
+     curl $CURLFLAGS -A "Internet Explorer" -o $TMPFILE --connect-timeout 30 $GLROOT$IMDBLKL/$TMBNAME >/dev/null 2>&1
+    fi
    fi
 
 # Should we run any external scripts?

--- a/scripts/psxc-imdb/main/psxc-imdb.sh
+++ b/scripts/psxc-imdb/main/psxc-imdb.sh
@@ -563,7 +563,7 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
     PLOT="Plot: "$(sed -n '/^ Plot Summary$/,/\(^ \\\* Plot \(Summary\|Synopsis\)\|Plot Keywords\)$/{//d;p;}' "$TMPFILE" | \
                    sed -e 's/\( \\\* Plot Summary\|Written by .*\)$//' -e '/(.*@.*)/d' | \
                    sed s/\"/$QUOTECHAR/g | sed 's/^\ *//g' | tr -s ' ' | sed "s/ *$//" | \
-                   fold -s -w $PLOTWIDTH | sed ':a;N;$!ba;s/\n/\\\\n/g' | sed 's/\(.\{1000\}\).*/\1.../' | grep ^[0-9A-Za-z])""
+                   fold -s -w $PLOTWIDTH | sed ':a;N;$!ba;s/\n/'"$NEWLINE"'/g' | sed 's/\(.\{1000\}\).*/\1.../' | grep ^[0-9A-Za-z])""
     PLOTCLEAN=$(echo $PLOT | sed "s/Plot: *//")
     if [ ! -z "$(echo "$PLOTCLEAN" | grep -a -e "\(\ \)\ \(\ \)")" ]; then
      OUTPUTOK=""
@@ -1008,7 +1008,7 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
     if [ ! -z "$PLOT" ]; then
      echo "-" >> "$IMDBLNK"
      #echo "$PLOT" | fold -s -w $IMDBWIDTH >> "$IMDBLNK"
-     echo "$PLOT" | sed 's/\\\\n//g' | fold -s -w $IMDBWIDTH >> "$IMDBLNK"
+     echo "$PLOT" | sed s/"$NEWLINE"//g | fold -s -w $IMDBWIDTH >> "$IMDBLNK"
     fi
     if [ ! -z "$SHOWCOMMENT" ] && [ ! -z "$COMMENT" ]; then
      echo "---" >> "$IMDBLNK"


### PR DESCRIPTION
Try 2

psxc-imdb.{sh,conf}

CHANGES:
- Get screens and ISLIMITED from Box Office Mojo (option USEBOM) #28
- Added option USEWIDEST to use "Widest Release" instead of "Opening" theaters
- Fixed PLOT and CAST, added PLOTWIDTH config option #28
- Added option to use Original Title instead of localized one (option USEORIGTITLE)
- Added option to USECURL and FLAGS for both curl and wget
- Fixed Businessdata (opening earnings in BUSINESSSHORT)
