### PR TITLE
#63 f_name if file in path for replacepath

### DIFF
--- a/sitebot/ngBot.tcl
+++ b/sitebot/ngBot.tcl
@@ -759,26 +759,32 @@ namespace eval ::ngBot {
 
 	proc replacepath {message basepath path} {
 		variable ns
+		set pathlast	[lindex [split $path "/"] end]
+		if { [regexp {(\..{3}|\.flac)$} $pathlast] } {
+			set path	[join [lrange [split $path "/"] 0 end-1] /]
+			set message	[${ns}::replacevar $message "%f_name" $pathlast]
+		}
+		unset pathlast
+		
+		set npath		[split $path "/"]
+		set pathitems	[llength $npath]
 
-		set npath [split $path "/"]
-		set pathitems [llength $npath]
-
-		set x 0
-		set bpaths [split $basepath " "]
-		set blength [llength $bpaths]
+		set x			0
+		set bpaths		[split $basepath " "]
+		set blength		[llength $bpaths]
 		while {$x < $blength && ![string match [lindex $bpaths $x] $path]} {
 			incr x
 		}
+		if { $x < $blength } {
+			set bpath		[lindex $bpaths $x]
+			set bnpath		[split $bpath "/"]
+			set baseitems	[llength $bnpath]
 
-		if {$x < $blength} {
-			set bpath [lindex $bpaths $x]
-			set bnpath [split $bpath "/"]
-			set baseitems [llength $bnpath]
-			set relname [join [lrange $npath [expr {$baseitems - 1}] end] "/"]
-
+			set relname		[join [lrange $npath [expr {$baseitems - 1}] end] "/"]
 			set message [${ns}::replacevar $message "%relname" $relname]
 			set message [${ns}::replacevar $message "%reldir" [lindex $npath [expr {$pathitems - 1}]]]
 			set message [${ns}::replacevar $message "%path" [lindex $npath [expr {$pathitems - 2}]]]
+			
 		}
 		return $message
 	}


### PR DESCRIPTION
Support for f_name for replacepath.
if the logdata path contains a filename with an .xxx or .flac extension, it will treat the end of the path as a file and replace %f_name with the filename.

Makes pzs-ng more flexible and for the correct use of XFERLOG #64