### PR TITLE
Correctly unload plugins

### DIFF
--- a/sitebot/ngBot.tcl
+++ b/sitebot/ngBot.tcl
@@ -242,7 +242,7 @@ namespace eval ::ngBot {
 		set ng_timer [utimer 1 ${ns}::readlogtimer]
 	}
 
-		proc init_plugins {} {
+	proc init_plugins {} {
 		variable ns
 
 		if {![namespace exists ${ns}::plugin]} { return }

--- a/sitebot/ngBot.tcl
+++ b/sitebot/ngBot.tcl
@@ -242,7 +242,7 @@ namespace eval ::ngBot {
 		set ng_timer [utimer 1 ${ns}::readlogtimer]
 	}
 
-	proc init_plugins {} {
+		proc init_plugins {} {
 		variable ns
 
 		if {![namespace exists ${ns}::plugin]} { return }
@@ -252,13 +252,13 @@ namespace eval ::ngBot {
 			switch -- [catch {${plugin}::init} error] {
 				-1 {
 					catch {${plugin}::deinit}
-					catch {namespace delete $plugin}
+					catch {${ns}::deinit_plugin $plugin}
 				}
 				0 { lappend loaded [namespace tail $plugin] }
 				default {
-					putlog "\[ngBot\] [namespace tail $plugin] Error :: Unable to load plugin: $error"
+					putlog "\[ngBot\] [namespace tail $plugin] Error :: Unable to load plugin: $error\n$::errorInfo"
 					catch {${plugin}::deinit}
-					catch {namespace delete $plugin}
+					catch {${ns}::deinit_plugin $plugin}
 				}
 			}
 		}
@@ -267,12 +267,69 @@ namespace eval ::ngBot {
 			putlog "\[ngBot\] Plugins Loaded: [join $loaded ", "]."
 		}
 	}
-
+	# Unload all plugins
+	proc deinit_allplugins {} {
+		variable ns
+		if {![namespace exists ${ns}::plugin]} { return }
+			foreach plugin [namespace children ${ns}::plugin] {
+				set plugin_name	[namespace tail $plugin]
+				catch {${ns}::deinit_plugin $plugin_name}
+			}
+	}
+	# Unload one plugin
+	proc deinit_plugin { plugin_name } {
+		variable ns
+		# Accept Plugin_name or namespace of plugin
+		if { [string match -nocase "*::plugin::*" $plugin_name] } {
+			set ns_plugin	"$plugin_name"
+			set plugin_name	[namespace tail $plugin_name]
+		} else {
+			set ns_plugin	"${ns}::plugin::$plugin_name"
+		}
+		# DeInit from scripts (script own backups, etc)
+		catch {${ns_plugin}::deinit}
+		# Find all binds of plugin and unbind
+		foreach binding [lsearch -inline -all -regexp [binds *${ns_plugin}*] " \{?(::)?${ns_plugin}"] {
+			set bind_name	[namespace tail [lindex $binding 4]]
+			set bind_type	[lindex $binding 0]
+			if { ![expr [catch {unbind [lindex $binding 0] [lindex $binding 1] [lindex $binding 2] [lindex $binding 4]}]] } {
+				putlog "\[ngBot\] info :: UnBind $bind_type: '$bind_name' from $plugin_name"
+				
+			} else {
+				putlog "\[ngBot\] Error ::  echec UnBind $bind_name from $plugin_name"
+			}
+		
+		}
+		# Stopping the timers of the plugin.
+		foreach running_timer [timers] {
+			if { [::tcl::string::match "*${ns_plugin}::*" [lindex $running_timer 1]] } {
+				putlog "\[ngBot\] info :: killtimer $running_timer"
+					killtimer [lindex $running_timer 2]
+				}
+			}
+		# Stopping the utimers of the plugin.
+		foreach running_utimer [utimers] {
+			if { [::tcl::string::match "*${ns_plugin}::*" [lindex $running_utimer 1]] } {
+				putlog "\[ngBot\] info :: killutimer $running_utimer"
+				killutimer [lindex $running_utimer 2] 
+			}
+		}
+		# Removing the package declaration
+		if { [expr ![catch {package present $plugin_name}]] } {
+			putlog "\[ngBot\] info :: Removing the package declaration"
+			package forget $plugin_name
+		}
+		# Removing the namespace declaration
+		catch {namespace delete ${ns_plugin}}
+	}
 	# Uses _ng to avoid being overwriten by namespace import.
+	
 	proc deinit_ng {type} {
 		variable ns
 		variable ng_timer
-
+		# before deinit all plugins 
+		catch {deinit_allplugins}
+		
 		catch {killutimer $ng_timer}
 
 		# Remove all binds bound to any procs that match ::ngBot::*


### PR DESCRIPTION
Plugins unloading is now done before deleting the parent namespace.
There were bugs because of this.

Creation of '**deinit_plugin** <plugin_name>' allows to unload a plugin.

Creation of '**deinit_allplugins**' allows to unload all plugins.

The '**deinit_allplugins**' is run in '**deinit_ng**' before unloading pzs.

in '**init_plugins**' when a module fails to load 'deinit_plugin' is run to clean the failed plugin.

Unloading a plugin by '**deinit_plugin**' does this:
- Execute '**deinit**' of the plugin if present
- Removes all types of binds existing in the plugins
- Removes all '**timers**' existing in the plugins
- Removes all '**utimers**' existing in the plugins
- Remove a package declaration if the plugin provides a package
- Remove the plugin namespace

deinit_plugin accepts two types of value:
- Namespace: **deinit_plugin** ::ngBot::plugin::Plugin_Name
- Plugin name: **deinit_plugin** Plugin_Name

To sum up: all plugins are correctly unloaded even if their deinit is badly defined.
the deinit no longer needs to 'kill' its (u) timers, unbind the binds, etc.
deinit of the plugin is now useful for performing some tasks before closing. Closing of its flows, saving in files, saving ...


Example of a rehash:
```

[22:07:40] #MalaGaM# rehash
Rehashing.
[22:07:40] Writing user file...
[22:07:39] Writing channel file...
[22:07:39] Rehashing ...
[22:07:39] [ngBot] info :: UnBind pub: 'Trigger' from MalaGaM-AutoWipeNuked
[22:07:39] [ngBot] info :: UnBind time: 'time:proc' from MalaGaM-AutoWipeNuked
[22:07:39] [ngBot] info :: UnBind pub: 'Trigger' from MalaGaM-Quotat
[22:07:39] [ngBot] info :: UnBind time: 'time:proc' from MalaGaM-Quotat
[22:07:39] [ngBot] info :: UnBind msg: 'Trigger' from TVMaze
[22:07:39] [ngBot] info :: UnBind pub: 'Trigger' from TVMaze
[22:07:39] [ngBot] info :: UnBind msg: 'SearchDcc' from psxc-IMDb
[22:07:39] [ngBot] info :: UnBind pub: 'Search' from psxc-IMDb
[22:07:39] Writing channel file...
[22:07:39] Listening for telnet connections on 0.0.0.0 port 3333 (all).
[22:07:39] bseen1.4.2c:  -- Bass's SEEN loaded --
[[22:07:39] Writing channel file...
[22:07:39] Userfile loaded, unpacking...
[22:07:39] [ngBot] Detected glftpd 2, running in standard mode.
[22:07:39] [ngBot] Number of logs found: 4
[22:07:39] [ngBot] Loading theme "scripts/pzs-ng/themes/MalaGaM.zst".
[22:19:34] [ngBot] [SUCCESS->MalaGaM-IncLink] Loaded successfully (Version: 0.1 - 2021-04-21).
[22:19:34] [ngBot] [SUCCESS->MalaGaM-MediaInfo] Loaded successfully (Version: 0.1 - 2021-04-21).
[22:19:34] [ngBot] [SUCCESS->MalaGaM-AutoWipeNuked] Loaded successfully (Version: 0.1 - 2021-04-21).
[22:19:34] [ngBot] [SUCCESS->MalaGaM-Tools] Loaded successfully (Version: 0.1 - 2021-04-21).
[22:19:34] [ngBot] [SUCCESS->MalaGaM-PreTime] Loaded successfully (Version: 0.1 - 2021-04-24).
[22:19:34] [ngBot] [SUCCESS->MalaGaM-Quotat] Loaded successfully (Version: 0.1 - 2021-04-21).
[22:19:34] [ngBot] [SUCCESS->MalaGaM-MySQL] Loaded successfully (Version: 0.1 - 2021-04-21).
[22:19:34] [ngBot] TVMaze :: Loaded successfully (Version: 20200223).
[22:19:34] [ngBot] psxc-imdb :: Loaded successfully. (Modes Enabled: Logging, Pre, Find)
[22:19:34] [ngBot] Plugins Loaded: MalaGaM-IncLink, MalaGaM-MediaInfo, MalaGaM-AutoWipeNuked, MalaGaM-Tools, MalaGaM-PreTime, MalaGaM-Quotat, MalaGaM-MySQL, TVMaze, psxc-IMDb.
[22:19:34] [ngBot] Loaded successfully!

```