### PR TITLE
Theme colors now between 0-99 in .zst

### DIFF
--- a/sitebot/ngBot.tcl
+++ b/sitebot/ngBot.tcl
@@ -1441,7 +1441,7 @@ namespace eval ::ngBot {
 		# We also do the justification and padding that is required for %r / %l / %m to work.
 		# And we alter text within %T{}, %U{} or %L{} to Titlecase, UPPERCASE or lowercase.
 		# bold and underline replacement should not be needed here...
-		while {[regexp {(%c(\d)\{([^\{\}]+)\}|%b\{([^\{\}]+)\}|%u\{([^\{\}]+)\}|%T\{([^\{\}]+)\}|%U\{([^\{\}]+)\}|%L\{([^\{\}]+)\}|%([lrm])(\d{1,3})\{([^\{\}]+)\})} $targetString matchString dud padOp padLength padString]} {
+		while {[regexp {(\d{1,2})\{([^\{\}]+)\}|%b\{([^\{\}]+)\}|%u\{([^\{\}]+)\}|%T\{([^\{\}]+)\}|%U\{([^\{\}]+)\}|%L\{([^\{\}]+)\}|%([lrm])(\d{1,3})\{([^\{\}]+)\})} $targetString matchString dud padOp padLength padString]} {
 			# Check if any innermost %r/%l/%m are present.
 			while {[regexp {%([lrm])(\d{1,3})\{([^\{\}]+)\}} $targetString matchString padOp padLength padString]} {
 				set tmpPadString $padString

--- a/sitebot/ngBot.tcl
+++ b/sitebot/ngBot.tcl
@@ -1473,10 +1473,10 @@ namespace eval ::ngBot {
 
 			set colorString [format "COLOR_%s_1" $section]
 			if {[lsearch -exact [array names theme] $colorString] != -1} {
-				regsub -all {%c(\d)\{([^\{\}]+)\}} $targetString {\\003$theme([format "COLOR_%s_" $section]\1)\2\\003} targetString
+				regsub -all {%c(\d{1,2})\{([^\{\}]+)\}} $targetString {\\003$theme([format "COLOR_%s_" $section]\1)\2\\003} targetString
 				regsub {\003(\d)(?!\d)} $targetString {\\0030\1} targetString
 			} else {
-				regsub -all {%c(\d)\{([^\{\}]+)\}} $targetString {\\003$theme(COLOR\1)\2\\003} targetString
+				regsub -all {%c(\d{1,2})\{([^\{\}]+)\}} $targetString {\\003$theme(COLOR\1)\2\\003} targetString
 				regsub {\003(\d)(?!\d)} $targetString {\\0030\1} targetString
 			}
 		}


### PR DESCRIPTION
Before the color codes can be from 0 to 9. now they can go up to 99.
In your zst files you can customize
`COLOR0-99 "CODECOLOR"`
and
`COLOR_SECTION_0-99 "CODECOLOR"`

```
# Default colors, used for all sections except those defined below
COLOR1		= "00"
COLOR1		= "01"
COLOR2		= "02"
COLOR3		= "03"
COLOR4		= "04"
...
COLOR13		= "13"
COLOR14		= "14"
COLOR15		= "15"


# Custom section colors. Use same section names as defined in dZSbot.conf.
# IMPORTANT: You MUST define the same number@colors as there are default colors for each section!
# If you have 3 default colors above, then each section below needs exactly 3 colors.
# Sections not defined here will use the default colors above.
#COLOR_GAMES_1	= "05"
#COLOR_GAMES_2	= "08"
#COLOR_GAMES_3	= "12"
....
#COLOR_GAMES_13	= "12"
#COLOR_GAMES_14	= "05"
#COLOR_GAMES_15	= "08"

#COLOR_APPS_1	= "06"
#COLOR_APPS_2	= "09"
#COLOR_APPS_3	= "13"

#COLOR_APPS_13	= "06"
#COLOR_APPS_14	= "09"
#COLOR_APPS_15	= "13"
```