### PR TITLE
be able to put color on the %vars

### DIFF
--- a/sitebot/ngBot.tcl
+++ b/sitebot/ngBot.tcl
@@ -1480,6 +1480,17 @@ namespace eval ::ngBot {
 				regsub {\003(\d)(?!\d)} $targetString {\\0030\1} targetString
 			}
 		}
+		# We are looking for all strings beginning with% and containing "A-Z_". No digit before% must be present.
+		# This identifies any strings like %reldir,%f_name, etc which have no color in front 
+		# and that in them there is RELDIR, F_NAME the color to be filled in is applied.
+		set RE {[^0-9]{1,2}(%([a-z_]+))};
+		foreach { matchString padOp padcontent } [regexp -inline -all $RE $targetString] {
+			set padcontent  [string toupper $padcontent]
+			if {[lsearch -exact [array names theme] $padcontent] != -1} {
+				set padcolor "\\003$theme($padcontent)$padOp\\003"
+				set targetString [string map [list $padOp $padcolor] $targetString]
+			}
+		}
 		return [subst $targetString]
 	}
 

--- a/sitebot/themes/default.zst
+++ b/sitebot/themes/default.zst
@@ -47,6 +47,30 @@ KBIT        = "%b{%value}Kbit/s"
 MBIT        = "%b{%value}Mbit/s"
 fakesection.INVITE = "iNViTE"
 
+# Default variable colors, used for all variables except those already defined below
+RELDIR				= "04"
+SECTION				= "05"
+
+G_NAME				= "12"
+
+U_NAME				= "12"
+U_SITEOP			= "12"
+U_IDLETIME			= "12"
+U_HOSTMARK			= "12"
+U_HOST				= "12"
+U_IP				= "12"
+
+R_GNAME				= "12"
+
+G_RACER_POSITION	= "15"
+G_RACER_NAME		= "12"
+G_RACER_AVGSPEED	= "12"
+
+U_RACER_POSITION	= "15"
+U_RACER_AVGSPEED	= "12"
+
+F_NAME				= "12"
+
 ## Default announce
 announce.DEFAULT                = "[%b{info  }] %msg"
 


### PR DESCRIPTION
Instead of putting color to each %reldir like this %c1{%reldir}, it is now possible to set `RELDIR = "01"` to apply the color to all %reldir that do not have colors defined.

If in our zst file (theme) you have defined
`
COLOR3		= "03"
RELDIR             = "04"

`

and that in our announcement you have
`announce.TEST = "%b{%reldir}"`
the release will be displayed with the colors 04 and in bold.

If your announcement is
`announce.TEST = "%b{%c3{%reldir}}"`
the release will be displayed with the colors 03 and in bold. because a color has already been defined for %reldir (here 03)

It works with all the variables you can find in ngBot.vars and that of custom scripts declaring variables.
The only condition is that the variable must be in uppercase and without the % in your zst file.
```

# Default variable colors, used for all variables except those already defined below
RELDIR				= "04"
SECTION				= "05"

G_NAME				= "12"

U_NAME				= "12"
U_SITEOP			= "12"
U_IDLETIME			= "12"
U_HOSTMARK			= "12"
U_HOST				= "12"
U_IP				= "12"

R_GNAME				= "12"

G_RACER_POSITION	= "15"
G_RACER_NAME		= "12"
G_RACER_AVGSPEED	= "12"

U_RACER_POSITION	= "15"
U_RACER_AVGSPEED	= "12"

F_NAME				= "12"
...
```