### PR TITLE
Fix curl skipping IP address provided in PASV reply when checking BNC

### DIFF
--- a/sitebot/ngBot.tcl
+++ b/sitebot/ngBot.tcl
@@ -1088,9 +1088,9 @@ namespace eval ::ngBot {
 
 			set response [clock clicks -milliseconds]
 			if {[istrue $bnc(SECURE)]} {
-				set status [catch {exec $binary(CURL) --disable-epsv --max-time $bnc(TIMEOUT) --ftp-ssl --insecure -u $bnc(USER):$bnc(PASS) ftp://$ip:$port 2>@stdout} reply]
+				set status [catch {exec $binary(CURL) --no-ftp-skip-pasv-ip --disable-epsv --max-time $bnc(TIMEOUT) --ftp-ssl --insecure -u $bnc(USER):$bnc(PASS) ftp://$ip:$port 2>@stdout} reply]
 			} else {
-				set status [catch {exec $binary(CURL) --disable-epsv --max-time $bnc(TIMEOUT) -u $bnc(USER):$bnc(PASS) ftp://$ip:$port 2>@stdout} reply]
+				set status [catch {exec $binary(CURL) --no-ftp-skip-pasv-ip --disable-epsv --max-time $bnc(TIMEOUT) -u $bnc(USER):$bnc(PASS) ftp://$ip:$port 2>@stdout} reply]
 			}
 			set response [expr {[clock clicks -milliseconds] - $response}]
 			set type "ONLINE"


### PR DESCRIPTION
[CVE-2020-8284](https://curl.se/docs/CVE-2020-8284.html) was fixed in curl by skipping the IP address provided in PASV reply by default.
This breaks sites using bouncers.
Fixed by turning the new default behaviour explicitly off.
curl's option --no-ftp-skip-pasv-ip has been available since [7.15.0](https://curl.se/changes.html#7_15_0) which was released in October 2005 so we can safely add it.
Also relevant because Debian buster [recently](https://security-tracker.debian.org/tracker/CVE-2020-8284) fixed this as well.
This also closes issue #61.